### PR TITLE
Clean up unitary_generator a bit

### DIFF
--- a/referenceqvm/unitary_generator.py
+++ b/referenceqvm/unitary_generator.py
@@ -179,8 +179,8 @@ def permutation_arbitrary(args, num_qubits):
     Done in preparation for arbitrary gate application on
     adjacent qubits.
 
-    :param tuple args: (int) Qubit indices in the order the gate is
-                 applied to.
+    :param Sequence args: (int) Qubit indices in the order the gate is
+        applied to.
     :param int num_qubits: Number of qubits in system
 
     :return:
@@ -191,11 +191,11 @@ def permutation_arbitrary(args, num_qubits):
     :rtype:  tuple (sparse_array, np.array, int)
     """
     # Don't permit NoneType or empty sequences, but allow 0
-    if args is None or (isinstance(args, Sequence) and not args):
-        raise ValueError("Need at least one qubit index to perform"
-                         "permutation")
-
-    if not isinstance(args, Sequence):
+    if isinstance(args, Sequence):
+        if not args:
+            raise ValueError("Need at least one qubit index to perform"
+                             "permutation")
+    else:
         args = [args]
 
     inds = np.array([value_get(x) for x in args])

--- a/referenceqvm/unitary_generator.py
+++ b/referenceqvm/unitary_generator.py
@@ -71,8 +71,7 @@ def lifted_gate(i, matrix, num_qubits):
     """
     # input is checked in parent function apply_gate()
     # Find gate size (number of qubits operated on)
-    quot, rem = divmod(np.log2(matrix.shape[0]), 1)
-    if rem > 0:
+    if (matrix.shape[0] & matrix.shape[0] - 1) != 0:
         raise TypeError("Invalid gate size. Must be power of 2! "
                         "Received {} size".format(matrix.shape))
     else:
@@ -285,8 +284,7 @@ def apply_gate(matrix, args, num_qubits):
                         "square matrix.")
 
     # Find gate size (number of qubits operated on)
-    quot, rem = divmod(np.log2(matrix.shape[0]), 1)
-    if rem > 0:
+    if (matrix.shape[0] & matrix.shape[0] - 1) != 0:
         raise TypeError("Invalid gate size. Must be power of 2! "
                         "Received {} size".format(matrix.shape))
     else:


### PR DESCRIPTION
1. Use Python's abstract base classes to remove strict
   type assertions where they're not necessary
1. Use Python's support for a more mathematical (and therefore
   verifiable) syntax for relations (e.g., `x < y < z`)
1. Removes the use of `divmod` and `np.log2` to calculate powers of 2
1. Be more Pythonic in general