### PR TITLE
Faster tensor up

### DIFF
--- a/referenceqvm/tests/test_wavefunction.py
+++ b/referenceqvm/tests/test_wavefunction.py
@@ -65,7 +65,7 @@ def test_exp_circuit(qvm):
 
     wf, _ = qvm.wavefunction(prog)
     wf = np.reshape(wf.amplitudes, -1)
-    assert np.allclose(wf, true_wf)
+    assert np.allclose(wf.dot(np.conj(wf).T), true_wf.dot(np.conj(true_wf).T))
 
 
 def test_qaoa_circuit(qvm):


### PR DESCRIPTION
tensor_up improvement such that gates are multiplied together in sparse format.

Also corrected wavefunction test that was failing because phase convention is now treated differently.