### PR TITLE
Update to tox to remove py2.7 support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py36
 
 [testenv]
 recreate=


### PR DESCRIPTION
Rigetti officially supports python 3.  We will no longer maintain
backwards compatability with python 2.